### PR TITLE
feat: accept optional arguments for selection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Flash provides quick code navigation using search labels, inspired by the popula
     *   Type the character of the displayed label to instantly move your cursor to the beginning of that target.
     *   If only one match remains after typing search characters, pressing "Enter" will jump to that match.
 *   **Visual Mode Selection (Select To)**:
-    *   If Flash is triggered while text is selected (visual mode), jumping to a target will extend the selection from the original selection's anchor to the new target position.
+    *   By default, if Flash is triggered while text is selected (visual mode), jumping to a target will extend the selection from the original selection's anchor to the new target position.
+    *   This behavior could be overridden by using the `select` argument: pass `{ "select": true }` to force selection mode even without existing selection, or `{ "select": false }` to force jump-only mode and discard any existing selection.
 *   **Minimal Distraction**:
     *   Non-matching text is dimmed to help you focus on potential targets.
     *   When jumping, the editor scrolls minimally (`TextEditorRevealType.Default`) to keep the target in view without disorienting centering.
@@ -31,11 +32,43 @@ Flash provides quick code navigation using search labels, inspired by the popula
 ## Commands
 
 *   `Flash: Trigger Jump` (ID: `flash-vscode.jump`): Activates the flash jump mode.
+    
+    Accepts an optional `args` object with a `select` property (boolean) to control selection behavior:
+    - `true` — Forces selection mode: extends selection from current cursor to jump target
+    - `false` — Forces jump mode: moves cursor without selecting, even if text is currently selected
+    - `undefined` (default) — Auto mode: maintains selection if text is already selected, otherwise just moves cursor
+
 *   `Flash: Cancel Jump` (ID: `flash-vscode.cancel`): Deactivates flash jump mode (also triggered by `Escape` key during an active session).
 
 ## Extension Settings
 
 *Currently, there are no specific settings for this extension. Future versions may include customization options.*
+
+## Keybinding Examples
+
+You can customize how Flash behaves by passing arguments in your `keybindings.json`:
+
+```json
+// Default Flash jump (auto-detects selection mode)
+{
+  "key": "ctrl+;",
+  "command": "flash-vscode.jump"
+}
+
+// Always select when jumping
+{
+  "key": "ctrl+shift+;",
+  "command": "flash-vscode.jump",
+  "args": { "select": true }
+}
+
+// Always jump without selecting
+{
+  "key": "ctrl+alt+;",
+  "command": "flash-vscode.jump",
+  "args": { "select": false }
+}
+```
 
 ## Known Issues
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,11 +205,16 @@ function jumpToPosition(editor: vscode.TextEditor, position: vscode.Position, se
 /**
  * Main command handler to initiate a flash jump session.
  */
-async function startFlashJumpSession(editor: vscode.TextEditor) {
+async function startFlashJumpSession(editor: vscode.TextEditor, args?: Record<PropertyKey, any>) {
     await clearCurrentFlashSession(); // Clear any previous session
 
     const initialSelection = editor.selection;
-    const selectionAnchor = !initialSelection.isEmpty ? initialSelection.anchor : undefined;
+    let selectionAnchor = !initialSelection.isEmpty ? initialSelection.anchor : undefined;
+    if (args?.select === true) {
+        selectionAnchor = initialSelection.anchor;
+    } else if (args?.select === false) {
+        selectionAnchor = undefined;
+    }
 
     const dimDecoration = vscode.window.createTextEditorDecorationType({
         // Dim unfocused text using a theme color for ghost text
@@ -260,8 +265,8 @@ async function startFlashJumpSession(editor: vscode.TextEditor) {
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand("flash-vscode.cancel", clearCurrentFlashSession),
-        vscode.commands.registerTextEditorCommand("flash-vscode.jump", (editor) => {
-            startFlashJumpSession(editor);
+        vscode.commands.registerTextEditorCommand("flash-vscode.jump", (editor, _, args) => {
+            startFlashJumpSession(editor, args);
         })
     );
 }


### PR DESCRIPTION
Currently, whether a selection is generated after jumping depends on whether there was a selection before jumping. However, sometimes users may want to force generation or cancellation of selection regardless of whether there was a selection before jumping.

Therefore, I added a `select` parameter to the `flash-vscode.jump` command to control whether a selection is generated when jumping. The specific usage is as follows:

```jsonc
[
    // Default behavior
    {
        "key": "alt+g",
        "command": "flash-vscode.jump",
        "when": "editorTextFocus"
    },

    // Force cancel selection
    {
        "key": "alt+ctrl+g",
        "command": "flash-vscode.jump",
        "when": "editorTextFocus",
        "args": {
            "select": false
        }
    },

    // Force generate selection
    {
        "key": "alt+shift+g",
        "command": "flash-vscode.jump",
        "when": "editorTextFocus",
        "args": {
            "select": true
        }
    }
]
```
