### PR TITLE
Restore label display to the left of matches with fallback to overlay at line start

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ function isCharEqual(a: string, b: string): boolean {
     return a.toLowerCase() === b.toLowerCase();
 }
 
-function createLabelDecoration(labelChar: string): vscode.TextEditorDecorationType {
+function createLabelDecoration(labelChar: string, isLineStart: boolean): vscode.TextEditorDecorationType {
     return vscode.window.createTextEditorDecorationType({
         before: {
             contentText: labelChar,
@@ -38,7 +38,7 @@ function createLabelDecoration(labelChar: string): vscode.TextEditorDecorationTy
             backgroundColor: new vscode.ThemeColor('badge.background'),
             fontWeight: 'bold',
             border: `1px solid ${new vscode.ThemeColor('badge.background').id}`,
-            margin: `0 0.2ch 0 0`, // top, right, bottom, left
+            margin: `0 0.2ch 0 ${isLineStart ? '0' : '-1.2ch'}`, // top, right, bottom, left
             width: '1ch', // Attempt to give the label box a more consistent width
             textDecoration: 'none; position: absolute; text-align: center;' // Use absolute positioning to prevent text shift
         }
@@ -134,7 +134,8 @@ function updateDecorations(
             break; // Not enough unique labels
         }
 
-        const labelDecoration = createLabelDecoration(chosenLabelChar);
+        const isLineStart = range.start.character === 0;
+        const labelDecoration = createLabelDecoration(chosenLabelChar, isLineStart);
         // The decoration itself is applied to a zero-width range at the start of the matched range.
         const labelAnchorRange = new vscode.Range(range.start, range.start);
 


### PR DESCRIPTION
## Description

Restore the label display positioning from #4, showing labels to the left of matched characters instead of directly overlaying them. When a match is at the beginning of a line (character position 0), the label falls back to overlay mode to prevent text overflow.

## Changes

- Modified `createLabelDecoration()` to accept an `isLineStart` parameter
- Adjusted the left margin of label decorations:
  - Normal position: `-1.2ch` (displays label to the left)
  - Line start position: `0` (overlays label on the match)
- Updated `updateDecorations()` to detect if a match is at line start and pass this information to `createLabelDecoration()`

## Rationale

This restores the improved visual presentation from #4 where labels appear beside matches rather than on top of them, making the underlying text more readable. The fallback behavior at line start ensures proper rendering when there's no space to the left.